### PR TITLE
Fix/level1 spawn bugs

### DIFF
--- a/Assets/Scripts/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Enemy/EnemySpawner.cs
@@ -12,8 +12,6 @@ public class EnemySpawner : MonoSingleton<EnemySpawner>
     [SerializeField]
     private float spawnRange = 10.0f;
     [SerializeField]
-    private float castRadius = 2.0f;
-    [SerializeField]
     private float spawnInterval = 15.0f;
     [SerializeField]
     private int spawnAmountPerInterval = 15;
@@ -92,9 +90,6 @@ public class EnemySpawner : MonoSingleton<EnemySpawner>
         float randomX = Random.Range(leftMost, rightMost);
         float randomY = Random.Range(bottomMost, topMost);
 
-        Vector2 randomPosition = new Vector2(randomX, randomY);
-        RaycastHit2D[] hits = Physics2D.CircleCastAll(randomPosition, castRadius, Vector2.zero);
-
         // Check 6 tiles around the random tile
         for (int x = (int)randomX - 1; x <= (int)randomX + 1; ++x)
         {
@@ -114,6 +109,10 @@ public class EnemySpawner : MonoSingleton<EnemySpawner>
             // Debug.DrawLine(player.position, randomPosition, Color.cyan, 2.0f);
             return 0;
         }
+
+        // Offset correction preventing enemy from spawning underground
+        randomY += 0.15f;
+        Vector2 randomPosition = new Vector2(randomX, randomY);
 
         randomY = Mathf.Ceil(randomY);
         Debug.DrawLine(player.position, randomPosition, Color.green, 2.0f);

--- a/Assets/Scripts/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Enemy/EnemySpawner.cs
@@ -22,6 +22,7 @@ public class EnemySpawner : MonoSingleton<EnemySpawner>
     private float enemyCostKilledThisStage = 0;
     private Transform player;
     private const int maxSpawnAttempts = 500;
+    private const float correctionOffsetY = 0.15f;
 
     private void Start()
     {
@@ -111,7 +112,7 @@ public class EnemySpawner : MonoSingleton<EnemySpawner>
         }
 
         // Offset correction preventing enemy from spawning underground
-        randomY += 0.15f;
+        randomY += correctionOffsetY;
         Vector2 randomPosition = new Vector2(randomX, randomY);
 
         randomY = Mathf.Ceil(randomY);


### PR DESCRIPTION
The bug supposedly caused by enemy spawning too close into the ground. The implemented solution was just moving the Y-axis of the spawn position up by a little (0.15f in this case)