### PR TITLE
Add difficulty scaling for enemy health and attack

### DIFF
--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -28,7 +28,7 @@ public class Enemy : Health
     public float SuperArmorPercentage => superArmor / maxSuperArmor;
     public Vector2 ForwardVector => turnDirection == MovementState.Right ? Vector2.right : Vector2.left;
     public MovementState TurnDirection => turnDirection;
-    public float AttackDamage => attackDamage;
+    public float AttackDamage => attackDamage * Difficulty.EnemyAttackScalingFactor;
 
     public float AttackRange => attackRange;
     public float AttackCooldown => attackCooldown / actionSpeed;
@@ -272,7 +272,7 @@ public class Enemy : Health
         superArmorBar.gameObject.SetActive(showSuperArmorBar);
 
         // Set health and super armor
-        base.maxHealth = startMaxHealth;
+        base.maxHealth = startMaxHealth * Difficulty.EnemyHealthScalingFactor;
         superArmor = maxSuperArmor;
 
         base.Start();

--- a/Assets/Scripts/EnemyAI/MeleeBossAttack.cs
+++ b/Assets/Scripts/EnemyAI/MeleeBossAttack.cs
@@ -32,6 +32,7 @@ public class MeleeBossAttack : EnemyAttack
     private float screenShakeDuration = 0.3f;
     [SerializeField]
     private float screenShakePower = 0.15f;
+    private float calculatedDamage => damage * Difficulty.EnemyAttackScalingFactor;
 
     private AttackHitbox attackHitbox;
 
@@ -47,7 +48,7 @@ public class MeleeBossAttack : EnemyAttack
             FindAttackHitboxByName();
         }
 
-        float damageDealt = MeleeAttack(attackHitbox, knockBackAmplitude, knockUpAmplitude, damage);
+        float damageDealt = MeleeAttack(attackHitbox, knockBackAmplitude, knockUpAmplitude, calculatedDamage);
         if (damageDealt > 0.0f)
         {
             // Hit player successfully

--- a/Assets/Scripts/Levels/LevelProgression.cs
+++ b/Assets/Scripts/Levels/LevelProgression.cs
@@ -12,7 +12,6 @@ public class LevelProgression : MonoSingleton<LevelProgression>
     {
         GameEvents.MoveToNextLevel += IncreaseStage;
         EventPublisher.EnemyDead += ProcessSpawnAmount;
-        Debug.Log(Difficulty.EnemyHealthScalingFactor);
     }
 
     private void OnDestroy()

--- a/Assets/Scripts/Levels/LevelProgression.cs
+++ b/Assets/Scripts/Levels/LevelProgression.cs
@@ -12,6 +12,7 @@ public class LevelProgression : MonoSingleton<LevelProgression>
     {
         GameEvents.MoveToNextLevel += IncreaseStage;
         EventPublisher.EnemyDead += ProcessSpawnAmount;
+        Debug.Log(Difficulty.EnemyHealthScalingFactor);
     }
 
     private void OnDestroy()
@@ -40,7 +41,6 @@ public class LevelProgression : MonoSingleton<LevelProgression>
     private void ProcessSpawnAmount(Enemy enemy)
     {
         enemyCostKilledThisStage += enemy.SpawnCost;
-        Debug.Log($"{enemyCostKilledThisStage}/{StageManager.CostToPassLevel}");
 
         // For normal stages, killing more than threshold should let the player pass level
         if (enemyCostKilledThisStage >= StageManager.CostToPassLevel)

--- a/Assets/Scripts/Statics/Difficulty.cs
+++ b/Assets/Scripts/Statics/Difficulty.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Difficulty
+{
+    public static float EnemyHealthScalingFactor =>
+        1.0f + ((StageManager.currentWorld - 1) * enemyHealthScalingPerWorld) + ((StageManager.currentStage - 1) * enemyHealthScalingPerLevel);
+    public static float EnemyAttackScalingFactor =>
+        1.0f + ((StageManager.currentWorld - 1) * enemyAttackScalingPerWorld) + ((StageManager.currentStage - 1) * enemyAttackScalingPerLevel);
+
+    private const float enemyHealthScalingPerWorld = 0.5f;
+    private const float enemyHealthScalingPerLevel = 0.1f;
+    private const float enemyAttackScalingPerWorld = 0.25f;
+    private const float enemyAttackScalingPerLevel = 0.05f;
+}

--- a/Assets/Scripts/Statics/Difficulty.cs.meta
+++ b/Assets/Scripts/Statics/Difficulty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 179a3cc7d579843959c69dba5cb877f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Statics/StageManager.cs
+++ b/Assets/Scripts/Statics/StageManager.cs
@@ -18,5 +18,4 @@ public class StageManager
     public static SpawnSide lastStageExitSide = SpawnSide.Left;
     public const int stageCountToFightBoss = 3; // How many normal stages before we fight boss?
     private const int baseEnemyCostToPassLevel = 20;
-    private const float difficultyScalingPerLevel = 0.25f;
 }


### PR DESCRIPTION
# Enemy Strength Scales by Stage and World Number
## General
- There are two factor in scaling: **world** and **stage**
- The first number in stage is called **world** and the second is **stage**
- For example. Stage `2-4` has `world=2` and `stage=4`

## How does it scale?
### The formula is simple
```
1.0f + ((world - 1) * worldScaleFactor) + ((stage - 1) * stageScaleFactor)
```
`worldScaleFactor` and `stageScaleFactor` are float, I aim to increase both enemy's `attack` and `health`, so there are 2 sets of `worldScaleFactor` and `stageScaleFactor` which are featured in `Difficulty.cs` as shown below:
```
private const float enemyHealthScalingPerWorld = 0.5f;
private const float enemyHealthScalingPerLevel = 0.1f;
private const float enemyAttackScalingPerWorld = 0.25f;
private const float enemyAttackScalingPerLevel = 0.05f;
``` 